### PR TITLE
Attempt to optimize TravisCI build time.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
   - sudo apt-get install libgeos-dev libproj-dev
   - sudo apt-get install make unzip python-sphinx
   - sudo /usr/bin/pip install --use-mirrors shapely nose pyshp pep8 mock
-  - sudo /usr/bin/pip install matplotlib
+#  - sudo /usr/bin/pip install matplotlib
   - sudo /usr/bin/pip install pyke netCDF4
   - sudo /usr/bin/pip install cdat-lite
   - sudo /usr/bin/pip install coverage
@@ -32,17 +32,17 @@ install:
 # Dependencies for iris and iris itself
 #
 # grib api
-  - sudo apt-get install libjasper-dev
-  - sudo apt-get build-dep libgrib-api-1.9.9 libgrib-api-dev libgrib-api-tools
-  - wget https://software.ecmwf.int/wiki/download/attachments/3473437/grib_api-1.9.16.tar.gz --no-check-certificate
-  - tar -xvf grib_api-1.9.16.tar.gz
-  - cd grib_api-1.9.16/
-  - CFLAGS="-fPIC" ./configure --with-jasper=/usr/local/lib --disable-fortran --enable-python
-  - make
-  - sudo make install
-  - cd python
-  - sudo /usr/bin/python setup.py install
-  - cd ../..
+#  - sudo apt-get install libjasper-dev
+#  - sudo apt-get build-dep libgrib-api-1.9.9 libgrib-api-dev libgrib-api-tools
+#  - wget https://software.ecmwf.int/wiki/download/attachments/3473437/grib_api-1.9.16.tar.gz --no-check-certificate
+#  - tar -xvf grib_api-1.9.16.tar.gz
+#  - cd grib_api-1.9.16/
+#  - CFLAGS="-fPIC" ./configure --with-jasper=/usr/local/lib --disable-fortran --enable-python
+#  - make
+#  - sudo make install
+#  - cd python
+#  - sudo /usr/bin/python setup.py install
+#  - cd ../..
 # distutils
   - wget http://python-distribute.org/distribute_setup.py
   - sudo /usr/bin/python distribute_setup.py


### PR DESCRIPTION
Most time is spent building dependencies. Removing matplotlib and the GRIB API from the dependencies makes the build faster without compromising on which tests can be run.
