### PR TITLE
Changed to setuptools to use 2to3.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 """Build and install the windspharm package."""
-from distutils.core import setup
+from setuptools import setup
 
 for line in open('lib/windspharm/__init__.py').readlines():
     if line.startswith('__version__'):
@@ -23,4 +23,5 @@ setup(name='windspharm',
       """,
       packages=packages,
       package_dir={'':'lib'},
-      package_data=package_data)
+      package_data=package_data,
+      use_2to3=True)


### PR DESCRIPTION
Hi, I'm packaging [windspharm for OpenSUSE 13.1](https://build.opensuse.org/package/show/home:ocefpaf/python3-windspharm) and, because this OpenSUSE release uses python3 as default, I made two simple changes in your `setup.py`.

Those changes to allow for a py3k package and they should not break anything for python2 (I tested only with python 2.7).

-Filipe

ps: Thanks for windspharm
