### PR TITLE
Python 3 support using setuptools and 2to3

### DIFF
--- a/.pyspharm.python3.patch
+++ b/.pyspharm.python3.patch
@@ -1,0 +1,44 @@
+--- setup.py	2014-02-07 19:49:39.050480448 +0000
++++ setup.py.fixed	2014-02-07 19:49:44.814480457 +0000
+@@ -3,6 +3,7 @@
+ # use "config_fc --fcompiler=gnu95 install" to build and install with
+ # another fortran compiler (e.g. gfortran).
+ 
++import setuptools
+ from numpy.distutils.core  import setup, Extension
+ import os, sys
+ 
+@@ -27,13 +28,13 @@
+  the terms of the SPHEREPACK license at
+  http://www2.cisl.ucar.edu/resources/legacy/spherepack/license\n
+  """)
+-    download = raw_input('Do you want to download SPHEREPACK now? (yes or no)')
++    download = input('Do you want to download SPHEREPACK now? (yes or no)')
+     if download not in ['Y','y','yes','Yes','YES']:
+         sys.exit(0)
+-    import urllib, tarfile
++    import urllib.request, tarfile
+     tarfname = 'spherepack3.2.tar'
+     URL="https://www2.cisl.ucar.edu/sites/default/files/"+tarfname
+-    urllib.urlretrieve(URL,tarfname)
++    urllib.request.urlretrieve(URL,tarfname)
+     if not os.path.isfile(tarfname):
+         raise IOError('Sorry, download failed')
+     tarf = tarfile.open(tarfname)
+@@ -44,7 +45,7 @@
+             mem = tarf.extractfile(f)
+             fout = open(ff,'w')
+             for line in mem.readlines():
+-                fout.write(line)
++                fout.write(line.decode('utf-8'))
+             fout.close()
+     tarf.close()
+ 
+@@ -57,5 +58,6 @@
+           url               = "http://code.google.com/p/pyspharm",
+           ext_modules       = [ext],
+ 	  packages          = ['spharm'],
+-	  package_dir       = {'spharm':'Lib'}
++	  package_dir       = {'spharm':'Lib'},
++      use_2to3=True,
+           )

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,76 +2,60 @@ language: python
 
 python:
   - "2.7"
+  - "3.3"
 
 install:
+  - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then
+        sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3E5C1192;
+        yes | sudo add-apt-repository ppa:ubuntugis/ubuntugis-unstable;
+        sudo apt-get update;
+        sudo apt-get install gfortran python-pip python-scipy python-numpy cython;
+        sudo apt-get install libudunits2-dev libhdf5-serial-dev libnetcdf-dev netcdf-bin;
+        sudo apt-get install libgeos-dev libproj-dev;
+        sudo apt-get install make unzip python-sphinx;
+        sudo /usr/bin/pip install --use-mirrors shapely pyshp pep8 mock nose;
+        sudo /usr/bin/pip install pyke netCDF4;
+        sudo /usr/bin/pip install cdat-lite;
+        sudo /usr/bin/pip install coverage;
+        mkdir ../prereqs && cd ../prereqs;
+        wget http://python-distribute.org/distribute_setup.py;
+        sudo /usr/bin/python distribute_setup.py;
+        git clone git://github.com/SciTools/cartopy.git;
+        cd cartopy;
+        git checkout v0.7.0;
+        sudo /usr/bin/python setup.py install;
+        cd ..;
+        git clone git://github.com/SciTools/iris.git;
+        cd iris;
+        git checkout v1.3.0;
+        /usr/bin/python setup.py std_names;
+        sudo /usr/bin/python setup.py install;
+        cd ..;
+        wget http://pyspharm.googlecode.com/files/pyspharm-1.0.8.tar.gz;
+        tar xfvz pyspharm-1.0.8.tar.gz;
+        cd pyspharm-1.0.8;
+        yes | sudo /usr/bin/python setup.py install;
+        cd ../../windspharm;
+    else
+        sudo apt-get install gfortran;
+        pip install nose coverage numpy;
+        mkdir ../prereqs && cd ../prereqs;
+        wget http://pyspharm.googlecode.com/files/pyspharm-1.0.8.tar.gz;
+        tar xfvz pyspharm-1.0.8.tar.gz;
+        cd pyspharm-1.0.8;
+        cp ../../windspharm/.pyspharm.python3.patch py3patch && patch -p0 < py3patch;
+        yes | python setup.py install;
+        cd ../../windspharm;
+    fi
 
-# add repository (from iris .travis.yml)
-  - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3E5C1192
-  - yes | sudo add-apt-repository ppa:ubuntugis/ubuntugis-unstable
-  - sudo apt-get update
-
-# install dependencies
-  - sudo apt-get install python-pip python-scipy cython
-  - sudo apt-get install gfortran
-  - sudo apt-get install libudunits2-dev libhdf5-serial-dev libnetcdf-dev netcdf-bin
-  - sudo apt-get install libgeos-dev libproj-dev
-  - sudo apt-get install make unzip python-sphinx
-  - sudo /usr/bin/pip install --use-mirrors shapely nose pyshp pep8 mock
-#  - sudo /usr/bin/pip install matplotlib
-  - sudo /usr/bin/pip install pyke netCDF4
-  - sudo /usr/bin/pip install cdat-lite
-  - sudo /usr/bin/pip install coverage
-
-#-----------------------------------------------------------------------------
-# create a directory to download and install dependencies in
-#
-  - mkdir ../prereqs
-  - cd ../prereqs
-
-#-----------------------------------------------------------------------------
-# Dependencies for iris and iris itself
-#
-# grib api
-#  - sudo apt-get install libjasper-dev
-#  - sudo apt-get build-dep libgrib-api-1.9.9 libgrib-api-dev libgrib-api-tools
-#  - wget https://software.ecmwf.int/wiki/download/attachments/3473437/grib_api-1.9.16.tar.gz --no-check-certificate
-#  - tar -xvf grib_api-1.9.16.tar.gz
-#  - cd grib_api-1.9.16/
-#  - CFLAGS="-fPIC" ./configure --with-jasper=/usr/local/lib --disable-fortran --enable-python
-#  - make
-#  - sudo make install
-#  - cd python
-#  - sudo /usr/bin/python setup.py install
-#  - cd ../..
-# distutils
-  - wget http://python-distribute.org/distribute_setup.py
-  - sudo /usr/bin/python distribute_setup.py
-# cartopy
-  - git clone git://github.com/SciTools/cartopy.git
-  - cd cartopy
-  - git checkout v0.7.0
-  - sudo /usr/bin/python setup.py install
-  - cd ..
-# iris
-  - git clone git://github.com/SciTools/iris.git
-  - cd iris
-  - git checkout v1.3.0
-  - /usr/bin/python setup.py std_names
-  - sudo /usr/bin/python setup.py install
-  - cd ..
-
-#-----------------------------------------------------------------------------
-# pyspharm is the primary dependency of windspharm
-#
-# pyspharm (1.0.8 required)
-  - wget http://pyspharm.googlecode.com/files/pyspharm-1.0.8.tar.gz
-  - tar xfvz pyspharm-1.0.8.tar.gz
-  - cd pyspharm-1.0.8
-  - yes | sudo /usr/bin/python setup.py install
-  - cd ../../windspharm
 
 script:
-  - /usr/bin/python tests.py --verbosity=2 --with-coverage --cover-package=windspharm
+  - if [[ $TRAVIS_PYTHON_VERSION  == 2* ]]; then
+        /usr/bin/python setup.py nosetests --verbosity=2 --with-coverage --cover-package=windspharm;
+    else
+        python setup.py nosetests --verbosity=2 --with-coverage --cover-package=windspharm;
+    fi
+        
 
 notifications:
   email: false

--- a/lib/windspharm/standard.py
+++ b/lib/windspharm/standard.py
@@ -285,7 +285,7 @@ class VectorWind(object):
                 lat = np.arange(90 - dlat / 2., -90, -dlat)
         try:
             cp = 2. * omega * np.sin(np.deg2rad(lat))
-        except TypeError, ValueError:
+        except (TypeError, ValueError):
             raise ValueError('invalid value for omega: {!r}'.format(omega))
         indices = [slice(0, None)] + [np.newaxis] * (len(self.u.shape) - 1)
         f = cp[indices] * np.ones(self.u.shape, dtype=np.float32)

--- a/setup.py
+++ b/setup.py
@@ -6,9 +6,11 @@ for line in open('lib/windspharm/__init__.py').readlines():
         exec(line)
 
 packages = ['windspharm',
-            'windspharm.examples']
+            'windspharm.examples',
+            'windspharm.tests' ]
 
-package_data = {'windspharm.examples': ['example_data/*']}
+package_data = {'windspharm.examples': ['example_data/*'],
+                'windspharm.tests': ['data/*.npy'],}
 
 setup(name='windspharm',
       version=__version__,


### PR DESCRIPTION
This PR implements Python3 support using setuptools and 2to3, based on #27. This approach avoids introducing the `six` dependency of #28 at the expense of moving to setuptools. Setuptools is pretty much standard now anyway so this is probably the preferred solution.

@ocefpaf - this includes your commit so you'll get credit. If you have any comments please feel free, otherwise this PR will be merged and #27 and #28 will be closed.
