### PR TITLE
Fix latitude dimension order issue in gradient and truncate.

### DIFF
--- a/lib/windspharm/cdms.py
+++ b/lib/windspharm/cdms.py
@@ -711,6 +711,9 @@ class VectorWind(object):
         # computation API.
         apiorder = 'yx' + ''.join([a for a in order if a not in 'xy'])
         chi = chi.reorder(apiorder)
+        # Do a region selection on the input to ensure the latitude dimension
+        # is north-to-south.
+        chi = chi(latitude=(90, -90))
         # Record the shape and axes in the API order.
         ishape = chi.shape
         axes = chi.getAxisList()
@@ -782,6 +785,9 @@ class VectorWind(object):
         # its axes to be compatible with the computation API.
         field = field.clone()
         field = field.reorder(apiorder)
+        # Do a region selection on the input to ensure the latitude dimension
+        # is north-to-south.
+        field = field(latitude=(90, -90))
         # Record the shape and axes in the API order.
         ishape = field.shape
         axes = field.getAxisList()

--- a/lib/windspharm/iris.py
+++ b/lib/windspharm/iris.py
@@ -715,6 +715,10 @@ class VectorWind(object):
         name = chi.name()
         lat, lat_dim = _dim_coord_and_dim(chi, 'latitude')
         lon, lon_dim = _dim_coord_and_dim(chi, 'longitude')
+        if (lat.points[0] < lat.points[1]):
+            # need to reverse latitude dimension
+            chi = reverse(chi, lat_dim)
+            lat, lat_dim = _dim_coord_and_dim(chi, 'latitude')
         apiorder, reorder = self._get_apiorder_reorder(chi, lat_dim, lon_dim)
         chi = chi.copy()
         chi.transpose(apiorder)
@@ -776,6 +780,10 @@ class VectorWind(object):
             raise TypeError('scalar field must be an iris cube')
         lat, lat_dim = _dim_coord_and_dim(field, 'latitude')
         lon, lon_dim = _dim_coord_and_dim(field, 'longitude')
+        if (lat.points[0] < lat.points[1]):
+            # need to reverse latitude dimension
+            chi = reverse(chi, lat_dim)
+            lat, lat_dim = _dim_coord_and_dim(chi, 'latitude')
         apiorder, reorder = self._get_apiorder_reorder(field, lat_dim, lon_dim)
         field = field.copy()
         field.transpose(apiorder)


### PR DESCRIPTION
These methods accept user input and the order of the latitude dimension should be forced to north-south in order for the methods to function correctly for all cases.