### PR TITLE
Use SciTools Binstar channel and test Python 3.4.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: python
 python:
     - "2.7"
     - "3.3"
+    - "3.4"
 
 install:
     # Make sure system components are up to date:
@@ -26,9 +27,8 @@ install:
     - conda install setuptools nose coverage numpy pyspharm
     # Additional dependencies for Python 2.x:
     - if [[ "$TRAVIS_PYTHON_VERSION" == 2* ]]; then
-        conda config --add channels rsignell;
+        conda config --add channels SciTools;
         conda install cdat-lite iris;
-        export UDUNITS2_XML_PATH=/home/travis/miniconda/envs/test-environment/share/udunits/udunits2.xml;
       fi
     # Install the package:
     - python setup.py install


### PR DESCRIPTION
Uses the SciTools Binstar channel to obtain iris and adds a suite for testing on Python 3.4.