### PR TITLE
Explicitly enable Travis container based builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ python:
     - "3.3"
     - "3.4"
 
+sudo: false
+
 install:
     # Install Miniconda so we can use it to manage dependencies:
     - if [[ "$TRAVIS_PYTHON_VERSION" == 2* ]]; then


### PR DESCRIPTION
The build is supposed to use containers if there is no sudo usage but this may not always be the case, setting it explicitly should do no harm.