### PR TITLE
Source code Python 2 and 3 compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,34 +1,51 @@
 language: python
 
-python:
-    - "2.7"
-    - "3.3"
-    - "3.4"
+env:
+    global:
+        - PACKAGES_STANDARD="setuptools nose coverage numpy pyspharm"
+    matrix:
+        - NAME="Python 2.7 (standard)"
+          PYTHON_VERSION=2.7
+          PACKAGES="${PACKAGES_STANDARD}"
+        - NAME="Python 2.7 (metadata)"
+          PYTHON_VERSION=2.7
+          PACKAGES="${PACKAGES_STANDARD} cdat-lite iris"
+        - NAME="Python 3.3 (standard)"
+          PYTHON_VERSION=3.3
+          PACKAGES="${PACKAGES_STANDARD}"
+        - NAME="Python 3.4 (standard)"
+          PYTHON_VERSION=3.4
+          PACKAGES="${PACKAGES_STANDARD}"
+        - NAME="Python 3.4 (metadata)"
+          PYTHON_VERSION=3.4
+          PACKAGES="${PACKAGES_STANDARD} iris"
+        - NAME="Python 3.5 (standard)"
+          PYTHON_VERSION=3.5
+          PACKAGES="${PACKAGES_STANDARD}"
 
 sudo: false
 
 install:
     # Install Miniconda so we can use it to manage dependencies:
     - if [[ "$TRAVIS_PYTHON_VERSION" == 2* ]]; then
-        wget http://repo.continuum.io/miniconda/Miniconda-3.4.2-Linux-x86_64.sh -O miniconda.sh;
+        wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
       else
-        wget http://repo.continuum.io/miniconda/Miniconda3-3.4.2-Linux-x86_64.sh -O miniconda.sh;
+        wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
       fi
     - bash miniconda.sh -b -p $HOME/miniconda
     - export PATH="$HOME/miniconda/bin:$PATH"
+    - hash -r
+    # Setup conda to use extra channels for dependencies:
     - conda config --set always_yes yes --set changeps1 no
+    - conda config --add channels scitools
     - conda config --add channels ajdawson
     - conda update conda
     - conda info -a
-    # Create a conda environment with the base dependencies:
-    - conda create -n test-environment python=$TRAVIS_PYTHON_VERSION
+    # Create a conda environment with the required Python version:
+    - conda create -n test-environment python=$PYTHON_VERSION
     - source activate test-environment
-    - conda install setuptools nose coverage numpy pyspharm
-    # Additional dependencies for Python 2.x:
-    - if [[ "$TRAVIS_PYTHON_VERSION" == 2* ]]; then
-        conda config --add channels SciTools;
-        conda install cdat-lite iris;
-      fi
+    # Install required packages:
+    - conda install ${PACKAGES}
     # Install the package:
     - python setup.py install
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -41,8 +41,8 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'windspharm'
-copyright = u'2012-2014, Andrew Dawson'
+project = 'windspharm'
+copyright = '2012-2014, Andrew Dawson'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -194,8 +194,8 @@ latex_elements = {
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('index', 'windspharm.tex', u'windspharm Documentation',
-   u'Andrew Dawson', 'manual'),
+  ('index', 'windspharm.tex', 'windspharm Documentation',
+   'Andrew Dawson', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -224,8 +224,8 @@ latex_domain_indices = False
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'windspharm', u'windspharm Documentation',
-     [u'Andrew Dawson'], 1)
+    ('index', 'windspharm', 'windspharm Documentation',
+     ['Andrew Dawson'], 1)
 ]
 
 # If true, show URL addresses after external links.
@@ -238,8 +238,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('index', 'windspharm', u'windspharm Documentation',
-   u'Andrew Dawson', 'windspharm', 'One line description of project.',
+  ('index', 'windspharm', 'windspharm Documentation',
+   'Andrew Dawson', 'windspharm', 'One line description of project.',
    'Miscellaneous'),
 ]
 
@@ -256,10 +256,10 @@ texinfo_documents = [
 # -- Options for Epub output ---------------------------------------------------
 
 # Bibliographic Dublin Core info.
-epub_title = u'windspharm'
-epub_author = u'Andrew Dawson'
-epub_publisher = u'Andrew Dawson'
-epub_copyright = u'2012, Andrew Dawson'
+epub_title = 'windspharm'
+epub_author = 'Andrew Dawson'
+epub_publisher = 'Andrew Dawson'
+epub_copyright = '2012, Andrew Dawson'
 
 # The language of the text. It defaults to the language option
 # or en if the language is not set.

--- a/doc/gh-pages.py
+++ b/doc/gh-pages.py
@@ -35,7 +35,7 @@ def sh2(cmd):
     """Execute command in a subshell, return stdout.
 
     Stderr is unbuffered from the subshell.x.
-    
+
     """
     p = Popen(cmd, stdout=PIPE, shell=True)
     out = p.communicate()[0]
@@ -49,7 +49,7 @@ def sh2(cmd):
 def init_repo(path):
     """Clone the gh-pages repo to a given location."""
     sh('git clone {} {}'.format(pages_repo, path))
-    here = os.getcwdu()
+    here = os.getcwd()
     cd(path)
     sh('git checkout gh-pages')
     cd(here)
@@ -65,9 +65,9 @@ if __name__ == '__main__':
         msg = sys.argv[1]
     except IndexError:
         msg = 'Updated documentation.'
-    
+
     # Check out the repository.
-    startdir = os.getcwdu()
+    startdir = os.getcwd()
     if not os.path.exists(pages_dir):
         # Initialize the repository.
         init_repo(pages_dir)
@@ -99,8 +99,8 @@ if __name__ == '__main__':
         sh('git commit -m "{}"'.format(msg))
 
         # Print a summary of last 3 commits.
-        print
-        print 'Most recent 3 commits to "gh-pages":'
+        print()
+        print('Most recent 3 commits to "gh-pages":')
         sys.stdout.flush()
         sh('git --no-pager log --oneline HEAD~3..')
 
@@ -110,6 +110,6 @@ if __name__ == '__main__':
         cd(startdir)
 
     # Print a summary message.
-    print
-    print 'Done. Please verify the build in: {}'.format(pages_dir)
-    print 'If everything looks good, "git push origin gh-pages"'
+    print()
+    print('Done. Please verify the build in: {}'.format(pages_dir))
+    print('If everything looks good, "git push origin gh-pages"')

--- a/lib/windspharm/iris.py
+++ b/lib/windspharm/iris.py
@@ -137,7 +137,7 @@ class VectorWind(object):
 
         """
         # Remove the latitude and longitude dimensions from an initial list.
-        apiorder = range(cube.ndim)
+        apiorder = list(range(cube.ndim))
         apiorder.remove(latitude)
         apiorder.remove(longitude)
         # Insert latitude and longitude at the front.
@@ -149,8 +149,9 @@ class VectorWind(object):
     def _metadata(self, var, **attributes):
         """Re-shape outputs and add meta-data."""
         var = var.reshape(self._ishape)
-        var = Cube(var,
-                   dim_coords_and_dims=zip(self._coords, range(var.ndim)))
+        var = Cube(
+            var,
+            dim_coords_and_dims=list(zip(self._coords, range(var.ndim))))
         var.transpose(self._reorder)
         for attribute, value in attributes.items():
             setattr(var, attribute, value)
@@ -728,10 +729,12 @@ class VectorWind(object):
         uchi, vchi = self._api.gradient(chi, truncation=truncation)
         uchi = uchi.reshape(ishape)
         vchi = vchi.reshape(ishape)
-        uchi = Cube(uchi,
-                    dim_coords_and_dims=zip(coords, range(uchi.ndim)))
-        vchi = Cube(vchi,
-                    dim_coords_and_dims=zip(coords, range(vchi.ndim)))
+        uchi = Cube(
+            uchi,
+            dim_coords_and_dims=list(zip(coords, range(uchi.ndim))))
+        vchi = Cube(
+            vchi,
+            dim_coords_and_dims=list(zip(coords, range(vchi.ndim))))
         uchi.transpose(reorder)
         vchi.transpose(reorder)
         uchi.long_name = 'zonal_gradient_of_{!s}'.format(name)
@@ -803,7 +806,7 @@ def _dim_coord_and_dim(cube, coord):
     the dimension number it corresponds to.
 
     """
-    coords = filter(lambda c: coord in c.name(), cube.dim_coords)
+    coords = [c for c in cube.dim_coords if coord in c.name()]
     if len(coords) > 1:
         raise ValueError('multiple {!s} coordinates not '
                          'allowed: {!r}'.format(coord, cube))

--- a/lib/windspharm/tests/reference.py
+++ b/lib/windspharm/tests/reference.py
@@ -86,7 +86,7 @@ def reference_solutions(container_type, gridtype):
             latdim = DimCoord(lats,
                               standard_name='latitude',
                               units='degrees_north')
-            coords = zip((latdim, londim), (0, 1))
+            coords = list(zip((latdim, londim), (0, 1)))
             for name in reference.keys():
                 reference[name] = Cube(reference[name],
                                        dim_coords_and_dims=coords,

--- a/lib/windspharm/tools.py
+++ b/lib/windspharm/tools.py
@@ -145,7 +145,7 @@ def recover_data(pdata, info):
     # Re-order dimensions correctly.
     rolldims = np.array([info['intermediate_order'].index(dim)
                          for dim in info['original_order'][::-1]])
-    for i in xrange(len(rolldims)):
+    for i in range(len(rolldims)):
         # Roll the axis to the front.
         data = np.rollaxis(data, rolldims[i])
         rolldims = np.where(rolldims < rolldims[i], rolldims + 1, rolldims)

--- a/setup.py
+++ b/setup.py
@@ -45,5 +45,4 @@ setup(name='windspharm',
       packages=packages,
       package_dir={'':'lib'},
       package_data=package_data,
-      use_2to3=True,
       install_requires=['numpy', 'pyspharm >= 1.0.8'],)


### PR DESCRIPTION
Modify the source code so it is both Python 2 and 3 compatible, removing the need to use `2to3` when installing on Python 3, and making it possible to run the tests suite against the source on Python 3.