### PR TITLE
Switch from Basemap to Cartopy for examples.

### DIFF
--- a/examples/cdms/rws_example.py
+++ b/examples/cdms/rws_example.py
@@ -3,12 +3,12 @@
 This example uses the cdms interface.
 
 """
-import numpy as np
+import cartopy.crs as ccrs
+import cdms2
 import matplotlib as mpl
 mpl.rcParams['mathtext.default'] = 'regular'
 import matplotlib.pyplot as plt
-from mpl_toolkits.basemap import Basemap
-import cdms2
+import numpy as np
 
 from windspharm.cdms import VectorWind
 from windspharm.examples import example_data_path
@@ -38,19 +38,17 @@ S = -eta * div - (uchi * etax + vchi * etay)
 
 # Pick out the field for December and add a cyclic point (the cyclic point is
 # for plotting purposes).
-S_dec = S(time=slice(11,12), longitude=(0,360), squeeze=True)
+S_dec = S(time=slice(11, 12), longitude=(0, 360), squeeze=True)
 
 # Plot Rossby wave source.
-m = Basemap(projection='cyl', resolution='c', llcrnrlon=0, llcrnrlat=-90,
-            urcrnrlon=360.01, urcrnrlat=90)
 lons, lats = S_dec.getLongitude()[:], S_dec.getLatitude()[:]
-x, y = m(*np.meshgrid(lons, lats))
+ax = plt.axes(projection=ccrs.PlateCarree(central_longitude=180))
 clevs = [-30, -25, -20, -15, -10, -5, 0, 5, 10, 15, 20, 25, 30]
-m.contourf(x, y, S_dec.asma()*1e11, clevs, cmap=plt.cm.RdBu_r,
-           extend='both')
-m.drawcoastlines()
-m.drawparallels((-90, -60, -30, 0, 30, 60, 90), labels=[1,0,0,0])
-m.drawmeridians((0, 60, 120, 180, 240, 300, 360), labels=[0,0,0,1])
-plt.colorbar(orientation='horizontal')
+fill = ax.contourf(lons, lats, S_dec.asma() * 1e11, clevs,
+                   transform=ccrs.PlateCarree(), cmap=plt.cm.RdBu_r,
+                   extend='both')
+ax.coastlines()
+ax.gridlines()
+plt.colorbar(fill, orientation='horizontal')
 plt.title('Rossby Wave Source ($10^{-11}$s$^{-1}$)', fontsize=16)
 plt.show()

--- a/examples/cdms/sfvp_example.py
+++ b/examples/cdms/sfvp_example.py
@@ -5,12 +5,12 @@ flow.
 This example uses the cdms interface.
 
 """
-import numpy as np
+import cartopy.crs as ccrs
+import cdms2
 import matplotlib as mpl
 mpl.rcParams['mathtext.default'] = 'regular'
 import matplotlib.pyplot as plt
-from mpl_toolkits.basemap import Basemap
-import cdms2
+import numpy as np
 
 from windspharm.cdms import VectorWind
 from windspharm.examples import example_data_path
@@ -34,31 +34,30 @@ sf, vp = w.sfvp()
 
 # Pick out the field for December and add a cyclic point (the cyclic point is
 # for plotting purposes).
-sf_dec = sf(time=slice(11,12), longitude=(0,360), squeeze=True)
-vp_dec = vp(time=slice(11,12), longitude=(0,360), squeeze=True)
+sf_dec = sf(time=slice(11, 12), longitude=(0, 360), squeeze=True)
+vp_dec = vp(time=slice(11, 12), longitude=(0, 360), squeeze=True)
 
 # Plot streamfunction.
-m = Basemap(projection='cyl', resolution='c', llcrnrlon=0, llcrnrlat=-90,
-            urcrnrlon=360.01, urcrnrlat=90)
+ax1 = plt.axes(projection=ccrs.PlateCarree(central_longitude=180))
 lons, lats = sf_dec.getLongitude()[:], sf_dec.getLatitude()[:]
-x, y = m(*np.meshgrid(lons, lats))
 clevs = [-120, -100, -80, -60, -40, -20, 0, 20, 40, 60, 80, 100, 120]
-m.contourf(x, y, sf_dec.asma()*1e-06, clevs, cmap=plt.cm.RdBu_r,
-           extend='both')
-m.drawcoastlines()
-m.drawparallels((-90, -60, -30, 0, 30, 60, 90), labels=[1,0,0,0])
-m.drawmeridians((0, 60, 120, 180, 240, 300, 360), labels=[0,0,0,1])
-plt.colorbar(orientation='horizontal')
+fill_sf = ax1.contourf(lons, lats, sf_dec.asma() * 1e-06, clevs,
+                       transform=ccrs.PlateCarree(), cmap=plt.cm.RdBu_r,
+                       extend='both')
+ax1.coastlines()
+ax1.gridlines()
+plt.colorbar(fill_sf, orientation='horizontal')
 plt.title('Streamfunction ($10^6$m$^2$s$^{-1}$)', fontsize=16)
 
 # Plot velocity potential.
 plt.figure()
+ax2 = plt.axes(projection=ccrs.PlateCarree(central_longitude=180))
 clevs = [-10, -8, -6, -4, -2, 0, 2, 4, 6, 8, 10]
-m.contourf(x, y, vp_dec.asma()*1e-06, clevs, cmap=plt.cm.RdBu_r,
-           extend='both')
-m.drawcoastlines()
-m.drawparallels((-90, -60, -30, 0, 30, 60, 90), labels=[1,0,0,0])
-m.drawmeridians((0, 60, 120, 180, 240, 300, 360), labels=[0,0,0,1])
-plt.colorbar(orientation='horizontal')
+fill_vp = ax2.contourf(lons, lats, vp_dec.asma() * 1e-06, clevs,
+                       transform=ccrs.PlateCarree(), cmap=plt.cm.RdBu_r,
+                       extend='both')
+ax2.coastlines()
+ax2.gridlines()
+plt.colorbar(fill_vp, orientation='horizontal')
 plt.title('Velocity Potential ($10^6$m$^2$s$^{-1}$)', fontsize=16)
 plt.show()

--- a/examples/iris/rws_example.py
+++ b/examples/iris/rws_example.py
@@ -52,10 +52,9 @@ S_dec = S.extract(time_constraint)
 # Plot Rossby wave source.
 clevs = [-30, -25, -20, -15, -10, -5, 0, 5, 10, 15, 20, 25, 30]
 ax = plt.subplot(111, projection=ccrs.PlateCarree(central_longitude=180))
-fill = iplt.contourf(S_dec*1e11, clevs, cmap=plt.cm.RdBu_r, extend='both')
+fill = iplt.contourf(S_dec * 1e11, clevs, cmap=plt.cm.RdBu_r, extend='both')
 ax.coastlines()
 ax.gridlines()
 plt.colorbar(fill, orientation='horizontal')
 plt.title('Rossby Wave Source ($10^{-11}$s$^{-1}$)', fontsize=16)
 plt.show()
-

--- a/examples/iris/sfvp_example.py
+++ b/examples/iris/sfvp_example.py
@@ -47,7 +47,8 @@ vp_dec = vp.extract(time_constraint)
 # Plot streamfunction.
 clevs = [-120, -100, -80, -60, -40, -20, 0, 20, 40, 60, 80, 100, 120]
 ax = plt.subplot(111, projection=ccrs.PlateCarree(central_longitude=180))
-fill_sf = iplt.contourf(sf_dec*1e-06, clevs, cmap=plt.cm.RdBu_r, extend='both')
+fill_sf = iplt.contourf(sf_dec * 1e-06, clevs, cmap=plt.cm.RdBu_r,
+                        extend='both')
 ax.coastlines()
 ax.gridlines()
 plt.colorbar(fill_sf, orientation='horizontal')
@@ -57,7 +58,8 @@ plt.title('Streamfunction ($10^6$m$^2$s$^{-1}$)', fontsize=16)
 plt.figure()
 clevs = [-10, -8, -6, -4, -2, 0, 2, 4, 6, 8, 10]
 ax = plt.subplot(111, projection=ccrs.PlateCarree(central_longitude=180))
-fill_vp = iplt.contourf(vp_dec*1e-06, clevs, cmap=plt.cm.RdBu_r, extend='both')
+fill_vp = iplt.contourf(vp_dec * 1e-06, clevs, cmap=plt.cm.RdBu_r,
+                        extend='both')
 ax.coastlines()
 ax.gridlines()
 plt.colorbar(fill_vp, orientation='horizontal')

--- a/examples/standard/sfvp_example.py
+++ b/examples/standard/sfvp_example.py
@@ -5,12 +5,14 @@ flow.
 This example uses the standard interface.
 
 """
-import numpy as np
+import cartopy.crs as ccrs
+from cartopy.mpl.ticker import LongitudeFormatter, LatitudeFormatter
+from cartopy.util import add_cyclic_point
 import matplotlib as mpl
 mpl.rcParams['mathtext.default'] = 'regular'
 import matplotlib.pyplot as plt
-from mpl_toolkits.basemap import Basemap, addcyclic
 from netCDF4 import Dataset
+import numpy as np
 
 from windspharm.standard import VectorWind
 from windspharm.tools import prep_data, recover_data, order_latdim
@@ -54,30 +56,43 @@ vp = recover_data(vp, uwnd_info)
 
 # Pick out the field for December and add a cyclic point (the cyclic point is
 # for plotting purposes).
-sf_dec, lons_c = addcyclic(sf[11], lons)
-vp_dec, lons_c = addcyclic(vp[11], lons)
+sf_dec, lons_c = add_cyclic_point(sf[11], lons)
+vp_dec, lons_c = add_cyclic_point(vp[11], lons)
 
 # Plot streamfunction.
-m = Basemap(projection='cyl', resolution='c', llcrnrlon=0, llcrnrlat=-90,
-            urcrnrlon=360.01, urcrnrlat=90)
-x, y = m(*np.meshgrid(lons_c, lats))
+ax1 = plt.axes(projection=ccrs.PlateCarree(central_longitude=180))
 clevs = [-120, -100, -80, -60, -40, -20, 0, 20, 40, 60, 80, 100, 120]
-m.contourf(x, y, sf_dec*1e-06, clevs, cmap=plt.cm.RdBu_r,
-           extend='both')
-m.drawcoastlines()
-m.drawparallels((-90, -60, -30, 0, 30, 60, 90), labels=[1,0,0,0])
-m.drawmeridians((0, 60, 120, 180, 240, 300, 360), labels=[0,0,0,1])
-plt.colorbar(orientation='horizontal')
+sf_fill = ax1.contourf(lons_c, lats, sf_dec * 1e-06, clevs,
+                       transform=ccrs.PlateCarree(), cmap=plt.cm.RdBu_r,
+                       extend='both')
+ax1.coastlines()
+ax1.gridlines()
+ax1.set_xticks([0, 60, 120, 180, 240, 300, 359.99], crs=ccrs.PlateCarree())
+ax1.set_yticks([-90, -60, -30, 0, 30, 60, 90], crs=ccrs.PlateCarree())
+lon_formatter = LongitudeFormatter(zero_direction_label=True,
+                                   number_format='.0f')
+lat_formatter = LatitudeFormatter()
+ax1.xaxis.set_major_formatter(lon_formatter)
+ax1.yaxis.set_major_formatter(lat_formatter)
+plt.colorbar(sf_fill, orientation='horizontal')
 plt.title('Streamfunction ($10^6$m$^2$s$^{-1}$)', fontsize=16)
 
 # Plot velocity potential.
 plt.figure()
+ax2 = plt.axes(projection=ccrs.PlateCarree(central_longitude=180))
 clevs = [-10, -8, -6, -4, -2, 0, 2, 4, 6, 8, 10]
-m.contourf(x, y, vp_dec*1e-06, clevs, cmap=plt.cm.RdBu_r,
-           extend='both')
-m.drawcoastlines()
-m.drawparallels((-90, -60, -30, 0, 30, 60, 90), labels=[1,0,0,0])
-m.drawmeridians((0, 60, 120, 180, 240, 300, 360), labels=[0,0,0,1])
-plt.colorbar(orientation='horizontal')
+vp_fill = ax2.contourf(lons_c, lats, vp_dec * 1e-06, clevs,
+                       transform=ccrs.PlateCarree(), cmap=plt.cm.RdBu_r,
+                       extend='both')
+ax2.coastlines()
+ax2.gridlines()
+ax2.set_xticks([0, 60, 120, 180, 240, 300, 359.99], crs=ccrs.PlateCarree())
+ax2.set_yticks([-90, -60, -30, 0, 30, 60, 90], crs=ccrs.PlateCarree())
+lon_formatter = LongitudeFormatter(zero_direction_label=True,
+                                   number_format='.0f')
+lat_formatter = LatitudeFormatter()
+ax2.xaxis.set_major_formatter(lon_formatter)
+ax2.yaxis.set_major_formatter(lat_formatter)
+plt.colorbar(vp_fill, orientation='horizontal')
 plt.title('Velocity Potential ($10^6$m$^2$s$^{-1}$)', fontsize=16)
 plt.show()


### PR DESCRIPTION
Update examples to use cartopy instead of basemap. The maps look pretty much the same and we no longer need basemap to be installed to build the docs.