### PR TITLE
Refresh the README to reflect recent changes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,51 +5,52 @@ windspharm - spherical harmonic vector wind analysis in Python
 Overview
 --------
 
-``windspharm`` is a Python package for computing quantities derived from global wind
+`windspharm` is a Python package for computing quantities derived from global wind
 fields using spherical harmonics, licensed under the MIT license.
-
-``windspharm`` provides a user-friendly interface for vector wind computations on the
-sphere (e.g., divergence, streamfunction etc.). ``windspharm`` is based on the
-[``pyspharm``](http://code.google.com/p/pyspharm/) module.
-
-``windspharm`` provides a replacement for the ``windfield`` package from CDAT (``windfield``
-was based on the ``sphere`` module, which is now deprecated).
+windspharm provides a user-friendly interface for vector wind computations on the
+sphere (e.g., divergence, streamfunction etc.). It is based on the
+[pyspharm](https://github.com/jswhit/pyspharm) module.
+windspharm provides a replacement for the windfield package from CDAT.
 
 
 Requirements
 ------------
 
-``windspharm`` only requires ``numpy`` and ``pyspharm`` (version 1.0.8 or higher), but for full functionality (meta-data interfaces) either or both of the [``iris``](http://scitools.org.uk/iris/) module or the ``cdms2`` module is required.
+`windspharm` only requires [`numpy`](http://numpy.org) and [`pyspharm`](https://github.com/jswhit/pyspharm) (version 1.0.8 or higher), but for full functionality (meta-data interfaces) one or more of [`iris`](http://scitools.org.uk/iris/), [`xarray`](http://xarray.pydata.org) or the `cdms2` module (from [UV-CDAT](http://uvcdat.llnl.gov) is required.
 The setuptools package is required for installation.
-``cdms2`` is part of the Climate Data Analysis Tools ([CDAT](http://www2-pcmdi.llnl.gov/cdat)) or can be obtained separately in the [cdat_lite](http://proj.badc.rl.ac.uk/ndg/wiki/CdatLite) package.
-``windspharm`` runs on Python 2 and 3.
+windspharm runs on Python 2 and 3.
 
 
 Documentation
 -------------
 
-Documentation is available [online](http://ajdawson.github.io/windspharm). The package
-docstrings are also very complete and can be used as a source of reference when working
-interactively.
+Documentation is available [online](http://ajdawson.github.io/windspharm).
+The package docstrings are also very complete and can be used as a source of reference when working interactively.
 
 
 Frequently asked questions
 --------------------------
 
-* **Do I need CDAT/``cdms2`` or ``iris`` to use ``windspharm``?**
-  No. All the computation code uses ``numpy`` only. The ``iris`` or ``cdms2`` modules
-  are only required for the meta-data preserving interfaces.
-* **Is ``windspharm`` a drop in replacement for ``windfield``?**
-  No. Because ``windspharm`` was written from scratch the naming conventions for methods
-  are different. Some new methods have been added compared to ``windfield``, and some
-  methods from ``windfield`` do not exist in ``windspharm``.
+* **Do I need UV-CDAT/iris/xarray to use windspharm?**
+  No. All the computation code uses numpy only. The iris, xarray and  cdms2 modules are only required for the meta-data preserving interfaces.
+* **Is windspharm a drop in replacement for windfield?**
+  No. Because windspharm was written from scratch the naming conventions for methods
+  are different. Some new methods have been added compared to windfield, and some
+  methods from windfield do not exist in windspharm.
 
 
 Installation
 ------------
 
-    python setup.py --user
+The easiest way to install is via [conda](http://conda.pydata.org) or pip:
 
-to install in your home directory, or to install system wide if you have permissions:
+    conda install -c ajdawson windspharm
 
-    sudo python setup.py install
+or
+
+    pip install windspharm
+
+You can also install from the source distribution.
+Just download the archive, unpack it, then enter the source directory and use:
+
+    python setup.py install


### PR DESCRIPTION
The contents of windspharm have changed (new interface) and the installation procedure is improved. In addition, the CDAT project has become UV-CDAT and cdat-lite is deprecated.