### PR TITLE
Advance version number on development branch.

### DIFF
--- a/lib/windspharm/__init__.py
+++ b/lib/windspharm/__init__.py
@@ -29,7 +29,7 @@ from . import tools
 __all__ = []
 
 # Package version number.
-__version__ = '1.4.x'
+__version__ = '1.5.dev0'
 
 try:
     from . import cdms


### PR DESCRIPTION
A release branch for 1.4.x has been cut, the development version number can be bumped up one minor version.