### PR TITLE
Add dependency lists to examples.

### DIFF
--- a/examples/cdms/rws_example.py
+++ b/examples/cdms/rws_example.py
@@ -2,6 +2,12 @@
 
 This example uses the cdms interface.
 
+Additional requirements for this example:
+
+* cdms2 (http://uvcdat.llnl.gov/)
+* matplotlib (http://matplotlib.org/)
+* cartopy (http://scitools.org.uk/cartopy/)
+
 """
 import cartopy.crs as ccrs
 import cdms2

--- a/examples/cdms/sfvp_example.py
+++ b/examples/cdms/sfvp_example.py
@@ -4,6 +4,12 @@ flow.
 
 This example uses the cdms interface.
 
+Additional requirements for this example:
+
+* cdms2 (http://uvcdat.llnl.gov/)
+* matplotlib (http://matplotlib.org/)
+* cartopy (http://scitools.org.uk/cartopy/)
+
 """
 import cartopy.crs as ccrs
 import cdms2

--- a/examples/iris/rws_example.py
+++ b/examples/iris/rws_example.py
@@ -2,6 +2,12 @@
 
 This example uses the iris interface.
 
+Additional requirements for this example:
+
+* iris (http://scitools.org.uk/iris/)
+* matplotlib (http://matplotlib.org/)
+* cartopy (http://scitools.org.uk/cartopy/)
+
 """
 import warnings
 

--- a/examples/iris/sfvp_example.py
+++ b/examples/iris/sfvp_example.py
@@ -4,6 +4,12 @@ flow.
 
 This example uses the iris interface.
 
+Additional requirements for this example:
+
+* iris (http://scitools.org.uk/iris/)
+* matplotlib (http://matplotlib.org/)
+* cartopy (http://scitools.org.uk/cartopy/)
+
 """
 import warnings
 

--- a/examples/standard/rws_example.py
+++ b/examples/standard/rws_example.py
@@ -2,6 +2,12 @@
 
 This example uses the standard interface.
 
+Additional requirements for this example:
+
+* netCDF4 (http://unidata.github.io/netcdf4-python/)
+* matplotlib (http://matplotlib.org/)
+* cartopy (http://scitools.org.uk/cartopy/)
+
 """
 import cartopy.crs as ccrs
 from cartopy.mpl.ticker import LongitudeFormatter, LatitudeFormatter

--- a/examples/standard/sfvp_example.py
+++ b/examples/standard/sfvp_example.py
@@ -4,6 +4,12 @@ flow.
 
 This example uses the standard interface.
 
+Additional requirements for this example:
+
+* netCDF4 (http://unidata.github.io/netcdf4-python/)
+* matplotlib (http://matplotlib.org/)
+* cartopy (http://scitools.org.uk/cartopy/)
+
 """
 import cartopy.crs as ccrs
 from cartopy.mpl.ticker import LongitudeFormatter, LatitudeFormatter

--- a/examples/xarray/rws_example.py
+++ b/examples/xarray/rws_example.py
@@ -2,6 +2,12 @@
 
 This example uses the xarray interface.
 
+Additional requirements for this example:
+
+* xarray (http://xarray.pydata.org)
+* matplotlib (http://matplotlib.org/)
+* cartopy (http://scitools.org.uk/cartopy/)
+
 """
 import cartopy.crs as ccrs
 import matplotlib as mpl

--- a/examples/xarray/sfvp_example.py
+++ b/examples/xarray/sfvp_example.py
@@ -4,6 +4,12 @@ flow.
 
 This example uses the xarray interface.
 
+Additional requirements for this example:
+
+* xarray (http://xarray.pydata.org)
+* matplotlib (http://matplotlib.org/)
+* cartopy (http://scitools.org.uk/cartopy/)
+
 """
 import cartopy.crs as ccrs
 import matplotlib as mpl


### PR DESCRIPTION
Add a listing of any extra dependencies required to run example scripts. The example scripts create plots, thus requiring matplotlib and cartopy which are not core dependencies of windspharm.