### PR TITLE
Further numpy 1.24 compatability: np.int_ -> int, np.bool_ -> bool

### DIFF
--- a/windspharm/_common.py
+++ b/windspharm/_common.py
@@ -116,5 +116,5 @@ def inspect_gridtype(latitudes):
 
 
 def to3d(array):
-    new_shape = array.shape[:2] + (np.prod(array.shape[2:], dtype=np.int_),)
+    new_shape = array.shape[:2] + (np.prod(array.shape[2:], dtype=int),)
     return array.reshape(new_shape)

--- a/windspharm/tests/test_error_handling.py
+++ b/windspharm/tests/test_error_handling.py
@@ -52,7 +52,7 @@ class TestStandardErrorHandlers(ErrorHandlersTest):
     def test_masked_values(self):
         # masked values in inputs should raise an error
         solution = reference_solutions(self.interface, self.gridtype)
-        mask = np.empty(solution['uwnd'].shape, dtype=np.bool_)
+        mask = np.empty(solution['uwnd'].shape, dtype=bool)
         mask[:] = False
         mask[1, 1] = True
         u = ma.array(solution['uwnd'], mask=mask, fill_value=1.e20)

--- a/windspharm/tools.py
+++ b/windspharm/tools.py
@@ -43,7 +43,7 @@ def __order_dims(d, inorder):
 
 
 def __reshape(d):
-    out = d.reshape(d.shape[:2] + (np.prod(d.shape[2:], dtype=np.int_),))
+    out = d.reshape(d.shape[:2] + (np.prod(d.shape[2:], dtype=int),))
     return out, d.shape
 
 


### PR DESCRIPTION
Despite #124, I was still getting errors from the `np.int_` and `np.bool_` calls.  Replacing them with the python `int` and `bool` fixed it for me.  This was with numpy 1.24.4 and python 3.10.6  Thanks!