### PR TITLE
ENH: use np.hypot for standard.magnitude

### DIFF
--- a/windspharm/standard.py
+++ b/windspharm/standard.py
@@ -137,7 +137,7 @@ class VectorWind(object):
             spd = w.magnitude()
 
         """
-        return (self.u ** 2 + self.v ** 2) ** 0.5
+        return np.hypot(self.u, self.v)
 
     def vrtdiv(self, truncation=None):
         """Relative vorticity and horizontal divergence.


### PR DESCRIPTION
[`np.hypot`](https://numpy.org/doc/stable/reference/generated/numpy.hypot.html) finds the length of the hypotenuse of a right triangle with leg lengths given by the arguments.  

The main benefit here would likely be locality (which should boost speed a bit): hypot would perform one pass through each array (two total) instead of the current four.  NumPy also tries to avoid over- and under-flow, but that's less of a concern if people pass winds mostly in the 0.1 m/s - 100 m/s range.

There might also be a small speed boost from using `sqrt` and `square` functions instead of a general power function, but I suspect this particular function is usually memory-limited, especially given the emphasis on SIMD in recent NumPy development.